### PR TITLE
Use the displayName for stacks instead of the stack name

### DIFF
--- a/b_aws_cdk_parallel/stack_dependencies.py
+++ b/b_aws_cdk_parallel/stack_dependencies.py
@@ -66,11 +66,13 @@ class StackDependencies:
         stack_dependency_graph = {}
         for name, artifact in cdk_manifest_json['artifacts'].items():
             if artifact['type'] == 'aws:cloudformation:stack':
+                # Get the display name (looks like a path).
+                displayName = artifact.get('displayName', name)
                 # Get all of the dependencies - both stacks and other resources.
                 dependencies = artifact.get('dependencies', [])
                 # Filter just the stack dependencies because we don't care about other resources.
                 dependencies = [d for d in dependencies if d in stacks]
-                stack_dependency_graph[name] = dependencies
+                stack_dependency_graph[displayName] = dependencies
 
         return stack_dependency_graph
 


### PR DESCRIPTION
Later versions of the CDK CLI warn you not to use the stack name, and to
instead use the "path-like" displayName to identify stacks that you supply to the
command line.

For example, if you have:
```
Stack1:
  - Stack2
```
And you run:
```
cdk deploy Stack2
```
You will see the warning:
```
Selecting stack by identifier "Stack2". This identifier is deprecated and will be removed in v2. Please use "Stack1/Stack2" instead.
```

This commit changes this library's behavior to use the "path-like" displayName
identifiers.
If the `"displayName"` attribute is not present in the CDK manifest file (eg. older versions of
the CDK CLI), then we fall back to using the stack name.
