### PR TITLE
Prevent CDK from trying to deploy dependencies on it's own.

### DIFF
--- a/b_aws_cdk_parallel/deploy_command.py
+++ b/b_aws_cdk_parallel/deploy_command.py
@@ -45,6 +45,8 @@ class DeployCommand:
         # We want to ensure that each stack deployment can have its own output.
         command += f' --output=./cdk_stacks/{self.__stack}'
         command += ' --progress events --require-approval never'
+        # Don't let CDK try to deploy dependencies - we have that covered.
+        command += ' --exclusively'
 
         cprint(PrintColors.OKBLUE, f'Executing command: {command}.')
         process = ContinuousSubprocess(command)


### PR DESCRIPTION
Because this library manages all of that on it's own, we don't need CDK
to deploy dependencies. If it tries then errors occur due to stacks
being updated multiple times (`AlreadyExistsException: ChangeSet
cdk-deploy-change-set cannot be created due to a mismatch with existing
attribute Description`).

Luckily, we can use the `--exclusive` flag on the `cdk` command to tell
it to only deploy the stack we specify.
